### PR TITLE
Fix csv file optional field bug

### DIFF
--- a/gitlab_users/gitlab_users.py
+++ b/gitlab_users/gitlab_users.py
@@ -440,7 +440,7 @@ def get_users_from_csv(filename):
         # Filter csv file header
         csvreader = csv.reader(row for row in csvfile
                                if not row.startswith('#'))
-        newusers = [dict(zip(fieldnames, row)) for row in csvreader]
+        newusers = [dict(map(None, fieldnames, row)) for row in csvreader]
 
         return newusers
 


### PR DESCRIPTION
KeyError when create user from csv file with only username, name
and email fields provided. Fix it by padding None value for unprovided fields.

You can now use csv file like this one:

```
# username, name, email, [organization], [location], [group], [access_level]
wayne,Bruce Wayne,bruce.wayne@wayne-entreprises.com
kent,Clark Kent,clark.kent@krypton.univ
```